### PR TITLE
fix(dlna): set correct sampleFrequency and bitsPerSample in DIDL-Lite

### DIFF
--- a/qobuz_proxy/backends/dlna/backend.py
+++ b/qobuz_proxy/backends/dlna/backend.py
@@ -622,8 +622,14 @@ class DLNABackend(AudioBackend):
         if metadata.artwork_url:
             didl += f"\n        <upnp:albumArtURI>{escape(metadata.artwork_url)}</upnp:albumArtURI>"
 
+        audio_attrs = ""
+        if metadata.sample_rate:
+            audio_attrs += f' sampleFrequency="{metadata.sample_rate}"'
+        if metadata.bit_depth:
+            audio_attrs += f' bitsPerSample="{metadata.bit_depth}"'
+
         didl += f"""
-        <res protocolInfo="{escape(protocol_info)}"{duration_attr}>{escape(url)}</res>
+        <res protocolInfo="{escape(protocol_info)}"{duration_attr}{audio_attrs}>{escape(url)}</res>
     </item>
 </DIDL-Lite>"""
 

--- a/qobuz_proxy/backends/types.py
+++ b/qobuz_proxy/backends/types.py
@@ -49,6 +49,8 @@ class BackendTrackMetadata:
     album: str = ""
     duration_ms: int = 0
     artwork_url: str = ""
+    sample_rate: int = 0  # Hz, e.g. 44100, 96000, 192000
+    bit_depth: int = 0  # e.g. 16, 24
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""

--- a/qobuz_proxy/playback/metadata.py
+++ b/qobuz_proxy/playback/metadata.py
@@ -50,6 +50,8 @@ class TrackMetadata:
     streaming_url: str = ""
     streaming_url_expires_at: int = 0  # Timestamp in seconds
     actual_quality: int = 0  # Quality ID of the streaming URL
+    sample_rate: int = 0  # Hz, e.g. 44100, 96000, 192000
+    bit_depth: int = 0  # e.g. 16, 24
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -198,6 +200,13 @@ class MetadataService:
         metadata = await self.get_metadata(track_id, fetch_url=True)
         return metadata.streaming_url if metadata else None
 
+    def get_track_format(self, track_id: str) -> tuple[int, int, int]:
+        """Return (actual_quality, sample_rate_hz, bit_depth) for a cached track, or (0, 0, 0)."""
+        cached = self._cache.get(track_id)
+        if cached:
+            return (cached.actual_quality, cached.sample_rate, cached.bit_depth)
+        return (0, 0, 0)
+
     def get_track_actual_quality(self, track_id: str) -> Optional[int]:
         """
         Get the actual streaming quality for a cached track.
@@ -278,6 +287,10 @@ class MetadataService:
                     # Use the actual format_id from API response (may differ from requested)
                     actual_quality = result.get("format_id", quality)
                     metadata.actual_quality = actual_quality
+                    # sampling_rate from Qobuz API is in kHz (e.g. 44.1, 96.0, 192.0)
+                    sr = result.get("sampling_rate", 0)
+                    metadata.sample_rate = int(float(sr) * 1000) if sr else 0
+                    metadata.bit_depth = int(result.get("bit_depth", 0))
 
                     if actual_quality != self._max_quality:
                         logger.info(

--- a/qobuz_proxy/playback/player.py
+++ b/qobuz_proxy/playback/player.py
@@ -738,6 +738,11 @@ class QobuzPlayer:
                     track.metadata = meta
                     track.duration_ms = meta.get("duration_ms", 0)
 
+            # Get actual quality and format info from cache (set during URL fetch)
+            actual_quality, sample_rate, bit_depth = self.metadata.get_track_format(
+                track.track_id
+            )
+
             # Build backend metadata
             backend_meta = BackendTrackMetadata(
                 track_id=track.track_id,
@@ -750,10 +755,9 @@ class QobuzPlayer:
                 album=meta.get("album", "") if meta else "",
                 duration_ms=track.duration_ms,
                 artwork_url=meta.get("artwork_url", "") if meta else "",
+                sample_rate=sample_rate,
+                bit_depth=bit_depth,
             )
-
-            # Get actual quality from cache (set during URL fetch)
-            actual_quality = self.metadata.get_track_actual_quality(track.track_id)
 
             # Log now playing with actual quality
             self.metadata.log_now_playing_info(backend_meta, actual_quality)
@@ -913,6 +917,7 @@ class QobuzPlayer:
 
             meta = await self._get_track_metadata(track_id)
 
+            _, sample_rate, bit_depth = self.metadata.get_track_format(track_id)
             backend_meta = BackendTrackMetadata(
                 track_id=track_id,
                 title=meta.get("title", f"Track {track_id}") if meta else f"Track {track_id}",
@@ -920,6 +925,8 @@ class QobuzPlayer:
                 album=meta.get("album", "") if meta else "",
                 duration_ms=meta.get("duration_ms", 0) if meta else 0,
                 artwork_url=meta.get("artwork_url", "") if meta else "",
+                sample_rate=sample_rate,
+                bit_depth=bit_depth,
             )
 
             success = await self.backend.set_next_track(url, backend_meta, queue_item_id)

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -67,6 +67,14 @@ class TestBackendTrackMetadata:
         assert metadata.album == ""
         assert metadata.duration_ms == 0
         assert metadata.artwork_url == ""
+        assert metadata.sample_rate == 0
+        assert metadata.bit_depth == 0
+
+    def test_audio_format_fields(self) -> None:
+        """Test sample_rate and bit_depth are stored correctly."""
+        metadata = BackendTrackMetadata(track_id="12345", sample_rate=96000, bit_depth=24)
+        assert metadata.sample_rate == 96000
+        assert metadata.bit_depth == 24
 
     def test_to_dict(self) -> None:
         """Test conversion to dictionary."""

--- a/tests/backends/test_dlna_backend.py
+++ b/tests/backends/test_dlna_backend.py
@@ -1,0 +1,88 @@
+"""Tests for DLNABackend._build_didl metadata generation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from qobuz_proxy.backends.types import BackendTrackMetadata
+from qobuz_proxy.backends.dlna.backend import DLNABackend
+
+
+def _make_backend() -> DLNABackend:
+    backend = DLNABackend.__new__(DLNABackend)
+    backend._capabilities = None
+    return backend
+
+
+def _make_metadata(**kwargs) -> BackendTrackMetadata:  # type: ignore[no-untyped-def]
+    defaults = {
+        "track_id": "1",
+        "title": "Test Track",
+        "artist": "Test Artist",
+        "album": "Test Album",
+        "duration_ms": 180000,
+        "artwork_url": "",
+    }
+    defaults.update(kwargs)
+    return BackendTrackMetadata(**defaults)
+
+
+class TestBuildDidl:
+    def test_hires_96k_includes_correct_audio_attributes(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=96000, bit_depth=24)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        assert 'sampleFrequency="96000"' in didl
+        assert 'bitsPerSample="24"' in didl
+
+    def test_hires_192k_includes_correct_audio_attributes(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=192000, bit_depth=24)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        assert 'sampleFrequency="192000"' in didl
+        assert 'bitsPerSample="24"' in didl
+
+    def test_cd_quality_includes_correct_audio_attributes(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=44100, bit_depth=16)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        assert 'sampleFrequency="44100"' in didl
+        assert 'bitsPerSample="16"' in didl
+
+    def test_no_audio_attributes_when_format_unknown(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=0, bit_depth=0)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        assert "sampleFrequency" not in didl
+        assert "bitsPerSample" not in didl
+
+    def test_audio_attributes_are_on_res_element(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=96000, bit_depth=24)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        # Attributes must appear inside the <res ...> tag, not elsewhere
+        res_start = didl.index("<res ")
+        res_end = didl.index(">", res_start)
+        res_tag = didl[res_start:res_end]
+        assert 'sampleFrequency="96000"' in res_tag
+        assert 'bitsPerSample="24"' in res_tag
+
+    def test_track_metadata_in_didl(self) -> None:
+        backend = _make_backend()
+        metadata = _make_metadata(sample_rate=96000, bit_depth=24)
+
+        didl = backend._build_didl("http://proxy/track.flac", metadata)
+
+        assert "Test Track" in didl
+        assert "Test Artist" in didl
+        assert "Test Album" in didl

--- a/tests/playback/test_metadata.py
+++ b/tests/playback/test_metadata.py
@@ -50,6 +50,8 @@ class TestTrackMetadata:
         assert metadata.streaming_url == ""
         assert metadata.streaming_url_expires_at == 0
         assert metadata.actual_quality == 0
+        assert metadata.sample_rate == 0
+        assert metadata.bit_depth == 0
 
     def test_to_dict(self) -> None:
         """Test conversion to dictionary."""
@@ -463,6 +465,83 @@ class TestMetadataService:
         """Test quality fallback with invalid max_quality returns full list."""
         service = MetadataService(MockAPIClient(), max_quality=99)  # type: ignore[arg-type]
         assert service._get_quality_fallback_order() == [27, 7, 6, 5]
+
+    @pytest.mark.asyncio
+    async def test_streaming_url_stores_sample_rate_and_bit_depth(
+        self, metadata_service: MetadataService, mock_api: MockAPIClient
+    ) -> None:
+        """Test that sample_rate and bit_depth from the API are stored on TrackMetadata."""
+        mock_api.get_track_metadata.return_value = {
+            "title": "Test Track",
+            "artist": "Test Artist",
+            "album": "Test Album",
+            "duration_ms": 180000,
+            "album_art_url": "",
+        }
+        mock_api.get_track_url.return_value = {
+            "url": "https://streaming.example.com/track.flac",
+            "format_id": 27,
+            "bit_depth": 24,
+            "sampling_rate": 96.0,  # kHz as returned by Qobuz API
+            "mime_type": "audio/flac",
+        }
+
+        result = await metadata_service.get_metadata("12345", fetch_url=True)
+
+        assert result is not None
+        assert result.sample_rate == 96000
+        assert result.bit_depth == 24
+
+    @pytest.mark.asyncio
+    async def test_streaming_url_stores_cd_quality_format(
+        self, metadata_service: MetadataService, mock_api: MockAPIClient
+    ) -> None:
+        """Test sample_rate and bit_depth for CD quality (16-bit/44.1kHz)."""
+        mock_api.get_track_metadata.return_value = {
+            "title": "Test Track",
+            "artist": "Test Artist",
+            "album": "Test Album",
+            "duration_ms": 180000,
+            "album_art_url": "",
+        }
+        mock_api.get_track_url.return_value = {
+            "url": "https://streaming.example.com/track.flac",
+            "format_id": 6,
+            "bit_depth": 16,
+            "sampling_rate": 44.1,
+            "mime_type": "audio/flac",
+        }
+
+        result = await metadata_service.get_metadata("12345", fetch_url=True)
+
+        assert result is not None
+        assert result.sample_rate == 44100
+        assert result.bit_depth == 16
+
+    def test_get_track_format_returns_values_after_url_fetch(
+        self, metadata_service: MetadataService
+    ) -> None:
+        """Test get_track_format returns cached quality, sample_rate, and bit_depth."""
+        from qobuz_proxy.playback.metadata import TrackMetadata
+
+        cached = TrackMetadata(track_id="12345", actual_quality=7, sample_rate=96000, bit_depth=24)
+        metadata_service._cache.set("12345", cached)
+
+        quality, sample_rate, bit_depth = metadata_service.get_track_format("12345")
+
+        assert quality == 7
+        assert sample_rate == 96000
+        assert bit_depth == 24
+
+    def test_get_track_format_returns_zeros_for_unknown_track(
+        self, metadata_service: MetadataService
+    ) -> None:
+        """Test get_track_format returns (0, 0, 0) for a track not in cache."""
+        quality, sample_rate, bit_depth = metadata_service.get_track_format("unknown")
+
+        assert quality == 0
+        assert sample_rate == 0
+        assert bit_depth == 0
 
     def test_log_now_playing(
         self, metadata_service: MetadataService, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
First of all, thank you very much for this project! I was looking for an alternative to my past setup using Roon (and its super expensive license) with Qobuz. Now my experience using Qobuz Connect is much better. 

I found this small issue while setting it up and asked Claude Code to fix it.

While setting up qobuz-proxy as a Roon alternative with a moOde/upmpdcli DLNA renderer, we noticed that audio was always playing at 44.1kHz regardless of the requested quality. Investigating via journalctl -u upmpdcli, we found that the DIDL-Lite metadata sent by qobuz-proxy to the renderer consistently declared sampleFrequency="44100" even when the proxy was correctly fetching and serving hi-res streams (e.g. 24-bit/96kHz) from Qobuz — as confirmed by the proxy's own log output (Now playing: ... FLAC Hi-Res (24-bit/96kHz)). Since upmpdcli trusts the declared sample rate in the DIDL-Lite and passes it to MPD, MPD was configuring the ALSA output at 44100Hz and resampling the stream before it reached the hardware, confirmed by reading /proc/asound/card2/pcm0p/sub0/hw_params showing rate: 44100 during playback of a 96kHz track. The fix is to populate sampleFrequency and bitsPerSample in the DIDL-Lite from the actual track metadata that the proxy already has at playback time, rather than using hardcoded or default values.

## Summary

- DIDL-Lite \`<res>\` element was missing \`sampleFrequency\` and \`bitsPerSample\` attributes, causing upmpdcli/MPD to default to 44100 Hz regardless of actual stream quality
- ALSA was resampling 96kHz/192kHz streams before they reached the hardware (confirmed via \`/proc/asound/.../hw_params\`)
- The Qobuz API already returns \`sampling_rate\` (kHz) and \`bit_depth\` in the track URL response — these values were simply not being forwarded to the DIDL-Lite XML

## Changes

- \`TrackMetadata\`: added \`sample_rate\` (Hz) and \`bit_depth\` fields, populated from the API response (\`sampling_rate\` is converted from kHz to Hz)
- \`BackendTrackMetadata\`: added \`sample_rate\` and \`bit_depth\` fields
- \`MetadataService.get_track_format()\`: new helper returning \`(quality, sample_rate, bit_depth)\` from cache
- \`player.py\`: both the main play path and gapless preload now populate audio format fields on \`BackendTrackMetadata\`
- \`DLNABackend._build_didl()\`: emits \`sampleFrequency\` and \`bitsPerSample\` on the \`<res>\` element when values are non-zero

## Tests

- New \`tests/backends/test_dlna_backend.py\`: covers \`_build_didl\` for Hi-Res 96k, Hi-Res 192k, CD quality, unknown format (attributes omitted), and attribute placement
- Extended \`tests/playback/test_metadata.py\`: covers kHz→Hz conversion, CD quality format, \`get_track_format()\` hit and miss
- Extended \`tests/backends/test_backends.py\`: covers new \`BackendTrackMetadata\` fields

438 existing tests + 13 new tests, all passing.